### PR TITLE
Do not index into Python arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 **/__pycache__
 **/*.c
 **/*.so
-
+**/perf.data*

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ upload: build
 	python3 -m twine upload wheelhouse/*
 
 bench: build
-	python3 -m timeit -s 'from base64 import b85encode ; x = bytes(range(256))' 'b85encode(x)'
-	python3 -m timeit -s 'from cb85 import b85encode ; x = bytes(range(256))' 'b85encode(x)'
+	python3 -m timeit -u usec -s 'from base64 import b85encode ; x = bytes(range(256))' 'b85encode(x)'
+	python3 -m timeit -u usec -s 'from cb85 import b85encode ; x = bytes(range(256))' 'b85encode(x)'
 
-	python3 -m timeit -s 'from base64 import b85decode, b85encode ; x = b85encode(bytes(range(256)))' 'b85decode(x)'
-	python3 -m timeit -s 'from cb85 import b85decode, b85encode ; x = b85encode(bytes(range(256)))' 'b85decode(x)'
+	python3 -m timeit -u usec -s 'from base64 import b85decode, b85encode ; x = b85encode(bytes(range(256)))' 'b85decode(x)'
+	python3 -m timeit -u usec -s 'from cb85 import b85decode, b85encode ; x = b85encode(bytes(range(256)))' 'b85decode(x)'
 
 test: build
 	python3 -m unittest

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ python -m pip install dist/cb85-*.whl
 
 ## Benchmark
 
-This library is between 2x to 10x faster depending on the size of the input
+This library is between 30x to 50x faster depending on the size of the input
 data. You can run these benchmarks yourself by running `make bench`:
 
 |             | CPython (usec) | `cb85` (usec) |
 |        ---: |           ---: |          ---: |
-| `b85encode` |           15.8 |          7.13 |
-| `b85decode` |           26.7 |          2.43 |
+| `b85encode` |           15.9 |         0.481 |
+| `b85decode` |           26.6 |         0.474 |
 
 ## Example
 

--- a/cb85/dec.pyx
+++ b/cb85/dec.pyx
@@ -12,6 +12,8 @@ cdef unsigned char *DECODE_B85 = [
 cpdef bytes b85decode(bytes x):
     cdef int sz = len(x)
     cdef bytearray out = bytearray(4 * sz // 5)
+    cdef unsigned char *z = x
+    cdef unsigned char *o = out
     cdef unsigned int acc, de
     cdef int i, j
     cdef int k = 0
@@ -21,15 +23,15 @@ cpdef bytes b85decode(bytes x):
 
         for j in range(5):
             if i + j < sz:
-                de = DECODE_B85[x[i+j]]
+                de = DECODE_B85[z[i+j]]
                 acc = 85 * acc + de
             else:
                 break
 
-        out[k+0] = (acc >> 24) & 0xff
-        out[k+1] = (acc >> 16) & 0xff
-        out[k+2] = (acc >>  8) & 0xff
-        out[k+3] =  acc        & 0xff
+        o[k+0] = (acc >> 24) & 0xff
+        o[k+1] = (acc >> 16) & 0xff
+        o[k+2] = (acc >>  8) & 0xff
+        o[k+3] =  acc        & 0xff
         k += 4
 
     return bytes(out)

--- a/cb85/enc.pyx
+++ b/cb85/enc.pyx
@@ -1,3 +1,5 @@
+import cython
+
 cdef unsigned char *ENCODE_B85 = [
     b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9',
     b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J',
@@ -11,25 +13,31 @@ cdef unsigned char *ENCODE_B85 = [
     b'|', b'}', b'~'
 ]
 
+@cython.cdivision(True)
 cpdef bytes b85encode(bytes x):
     cdef int sz = len(x)
-    cdef int padding = (-sz) % 4
+    cdef int padding = sz % 4
+    if padding > 0:
+        padding = 4 - padding
+
     cdef bytearray out = bytearray(5 * (sz + padding) // 4)
+    cdef unsigned char *z = x
+    cdef unsigned char *o = out
     cdef unsigned int acc
     cdef int j = 0
     cdef int i
 
     for i in range(0, len(x), 4):
-        acc = (x[i+0] << 24) \
-            | ((x[i+1] if i+1 < sz else 0) << 16) \
-            | ((x[i+2] if i+2 < sz else 0) << 8) \
-            | (x[i+3] if i+3 < sz else 0);
+        acc = (z[i+0] << 24) \
+            | ((z[i+1] if i+1 < sz else 0) << 16) \
+            | ((z[i+2] if i+2 < sz else 0) << 8) \
+            | (z[i+3] if i+3 < sz else 0)
 
-        out[j+0] = ENCODE_B85[acc // 52200625]
-        out[j+1] = ENCODE_B85[(acc // 614125) % 85]
-        out[j+2] = ENCODE_B85[(acc // 7225) % 85]
-        out[j+3] = ENCODE_B85[(acc // 85) % 85]
-        out[j+4] = ENCODE_B85[acc % 85]
+        o[j+0] = ENCODE_B85[acc // 52200625]
+        o[j+1] = ENCODE_B85[(acc // 614125) % 85]
+        o[j+2] = ENCODE_B85[(acc // 7225) % 85]
+        o[j+3] = ENCODE_B85[(acc // 85) % 85]
+        o[j+4] = ENCODE_B85[acc % 85]
         j += 5
 
     return bytes(out)


### PR DESCRIPTION
Read and write into a memory view of the Python input / output arrays to avoid having to call external functions for every indexing operation.