### PR TITLE
Produce unpadded output by default

### DIFF
--- a/cb85/dec.pyx
+++ b/cb85/dec.pyx
@@ -11,7 +11,11 @@ cdef unsigned char *DECODE_B85 = [
 
 cpdef bytes b85decode(bytes x):
     cdef int sz = len(x)
-    cdef bytearray out = bytearray(4 * sz // 5)
+    cdef int padding = sz % 5
+    if padding > 0:
+        padding = 5 - padding
+
+    cdef bytearray out = bytearray(4 * (sz + padding) // 5)
     cdef unsigned char *z = x
     cdef unsigned char *o = out
     cdef unsigned int acc, de
@@ -26,7 +30,8 @@ cpdef bytes b85decode(bytes x):
                 de = DECODE_B85[z[i+j]]
                 acc = 85 * acc + de
             else:
-                break
+                de = DECODE_B85[0x7e]
+                acc = 85 * acc + de
 
         o[k+0] = (acc >> 24) & 0xff
         o[k+1] = (acc >> 16) & 0xff
@@ -34,4 +39,7 @@ cpdef bytes b85decode(bytes x):
         o[k+3] =  acc        & 0xff
         k += 4
 
-    return bytes(out)
+    cdef result = bytes(out)
+    if padding:
+        result = result[:-padding]
+    return result

--- a/cb85/enc.pyx
+++ b/cb85/enc.pyx
@@ -14,7 +14,7 @@ cdef unsigned char *ENCODE_B85 = [
 ]
 
 @cython.cdivision(True)
-cpdef bytes b85encode(bytes x):
+cpdef bytes b85encode(bytes x, bint pad=False):
     cdef int sz = len(x)
     cdef int padding = sz % 4
     if padding > 0:
@@ -40,4 +40,7 @@ cpdef bytes b85encode(bytes x):
         o[j+4] = ENCODE_B85[acc % 85]
         j += 5
 
-    return bytes(out)
+    cdef result = bytes(out)
+    if padding and not pad:
+        result = result[:-padding]
+    return result

--- a/fuzz.py
+++ b/fuzz.py
@@ -8,12 +8,19 @@ with atheris.instrument_imports():
     import base64
 
 def test_single_input(data):
-    encoded = cb85.b85encode(data)
+    encoded = cb85.b85encode(data, pad=True)
     if encoded != base64.b85encode(data, pad=True):
-        raise RuntimeError(f'encode difference for input -- {data}')
+        raise RuntimeError(f'encode difference for padded input -- {data}')
 
     if cb85.b85decode(encoded) != base64.b85decode(encoded):
-        raise RuntimeError(f'decode difference for input -- {encoded}')
+        raise RuntimeError(f'decode difference for padded input -- {encoded}')
+
+    encoded = cb85.b85encode(data, pad=False)
+    if encoded != base64.b85encode(data, pad=False):
+        raise RuntimeError(f'encode difference for unpadded input -- {data}')
+
+    if cb85.b85decode(encoded) != base64.b85decode(encoded):
+        raise RuntimeError(f'decode difference for unpadded input -- {encoded}')
 
 atheris.Setup(sys.argv, test_single_input)
 atheris.Fuzz()


### PR DESCRIPTION
Thanks for this project! I got a 40x speedup in my use case, but I need the encode/decode cycle to not add padding to the original data, so I implemented this.

Edited to add: I guess I should call out that this changes the default behavior; the default now matches the Python standard library. This is backwards breaking, but since cb85 is zerover, I don't think that's an issue.